### PR TITLE
Use 'docker run -e' approach for supplying parameters to script in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,6 @@ FROM inclusivedesign/centos-devel:7
 COPY build.sh /root/build.sh
 
 RUN chmod 755 /root/build.sh
+
+# Environment variables will need to be set when running the container - see README.md for examples
+CMD /root/build.sh $PACKAGE_NAME $PACKAGE_REPO $OUTPUT_DIR $DEPS_DIR

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Container images that includes support tools to builds RPMs for CentOS
 
  - `PACKAGE_NAME`: *required*: name of the package to build (should match specfile for the package repo)
  - `PACKAGE_REPO`: *required*: URL of GitHub repo to pull the package from
- - `OUTPUT_DIR`: *required*: output directory on Docker container to store packages
+ - `OUTPUT_DIR`: *required*: output directory on Docker container to store packages. Typically, you'll want to bind this to a host volume as well to keep the outputted packages.
  - `DEPS_DIR`: *optional*: directory of dependency local packages to install before building the package (this can use packages from the host system with volume binding, as shown below)
 
 ### Example - building couchdb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # docker-centos-rpm-builder
 Container images that includes support tools to builds RPMs for CentOS
 
-## Build packages
+## Build the container
 
-    docker 
+`docker build -t idi-ops/centos-rpm-builder .`
+
+## Build packages in a container, dispose of the container, and keep the packages locally
+
+ Environment variables must be specified at run time for the container to function:
+
+ - `PACKAGE_NAME`: *required*: name of the package to build (should match specfile for the package repo)
+ - `PACKAGE_REPO`: *required*: URL of GitHub repo to pull the package from
+ - `OUTPUT_DIR`: *required*: output directory on Docker container to store packages
+ - `DEPS_DIR`: *optional*: directory of dependency local packages to install before building the package (this can use packages from the host system with volume binding, as shown below)
+
+### Example - building couchdb
+
+#### Make a directory to store the packages
+
+mkdir output
+
+#### Build erlang-mochiweb dependency
+
+```
+docker run --rm -v $PWD/output:/pkgs -it \
+-e PACKAGE_NAME=erlang-mochiweb \
+-e PACKAGE_REPO=https://github.com/gtirloni/rpm-centos-mochiweb \
+-e OUTPUT_DIR=/pkgs \
+idi-ops/centos-rpm-builder
+```
+
+#### Build couchdb
+
+```
+docker run --rm -v $PWD/output:/pkgs -it \
+-e PACKAGE_NAME=couchdb \
+-e PACKAGE_REPO=https://github.com/gtirloni/rpm-centos-couchdb \
+-e OUTPUT_DIR=/pkgs \
+-e DEPS_DIR=/pkgs \
+idi-ops/centos-rpm-builder
+```


### PR DESCRIPTION
@gtirloni - uses the Docker environment variables as discussed.

I also think the script's logical check for the correct number of parameters wasn't working as-is due to inverted logic (disguised by the test itself having slightly off syntax that I think was causing it not to execute) , which I've fixed. The script will now (as expected) fail if not passed 3 or 4 parameters.